### PR TITLE
	modified:   awot/io/flight.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Timothy Lang
 
 Andrew Lyons
 
+Steve Nesbitt
+
 ## Installation
 The latest source code for AWOT can be obtained from the GitHub repository,
 [https://github.com/nguy/AWOT](https://github.com/nguy/AWOT).

--- a/awot/io/flight.py
+++ b/awot/io/flight.py
@@ -239,7 +239,7 @@ def _make_data_dictionary(ncFile, name_map, isRAF, RAFdim=None):
 #########################
 
 
-def read_nasa_ames(filename, mapping_dict=None, platform=None):
+def read_nasa_ames(filename, mapping_dict=None, platform=None, verbose=False):
     '''
     Read NASA AMES FFI 1001 formatted data files.
     The header tells all about the file. Find format here:
@@ -258,6 +258,9 @@ def read_nasa_ames(filename, mapping_dict=None, platform=None):
     platform : str
         If value is set and valid, use the default mapping
         dictionary provided for that platform.
+    verbose : bool
+        Set to `True` to see how variables in the file are matched to
+        AWOT variable naming conventions (default = `False`)
     '''
     f = open(filename, 'r')
 
@@ -277,7 +280,7 @@ def read_nasa_ames(filename, mapping_dict=None, platform=None):
             name_map = _get_name_map(platform)
         else:
             name_map = _make_name_map_from_varlist(hdr['VNAME'])
-    print(name_map)
+
     # Loop through the variables and pull data
     readfile = {}
 
@@ -308,21 +311,21 @@ def read_nasa_ames(filename, mapping_dict=None, platform=None):
     readfile['time'] = Time
 
     data = {}
-    print(readfile)
     sht_var = [elem[:37].lower() for elem in readfile.keys()]
-    print(sht_var)
-    print('keys')
-    print(name_map.keys())
     for varname in name_map:
         try:
             matching = sht_var.index(name_map[varname][:37].lower())
-            print(varname, matching, list(readfile.keys())[matching])
             data[varname] = common._nasa_ames_var_to_dict(
-                               readfile[list(readfile.keys())[matching]],
-                               varname, name_map[varname])
+                readfile[list(readfile.keys())[matching]],
+                varname, name_map[varname])
+            if verbose:
+                print('{} -> {}'.format(varname,
+                      list(readfile.keys())[matching]))
 
         except:
             data[varname] = None
+            if verbose:
+                print('{} -> NO MATCH'.format(varname))
 
     # Calculate U,V wind if not present
     if 'Uwind' not in name_map:

--- a/awot/io/flight.py
+++ b/awot/io/flight.py
@@ -201,7 +201,8 @@ def _make_data_dictionary(ncFile, name_map, isRAF, RAFdim=None):
     dd = {}
 
     for var in name_map:
-        if name_map[var] in ncFile.variables.keys():
+        matching = [s for s in ncFile.variables.keys() if var[0:5] in s]
+        if (len(matching) > 0):
             dd[var] = common._ncvar_to_dict(ncFile.variables[name_map[var]])
             data = ncFile.variables[name_map[var]]
 #            if (isRAF) & (RAFrate in ncFile.variables[name_map[var]].shape):

--- a/awot/io/flight.py
+++ b/awot/io/flight.py
@@ -201,7 +201,9 @@ def _make_data_dictionary(ncFile, name_map, isRAF, RAFdim=None):
     dd = {}
 
     for var in name_map:
-        matching = [s for s in ncFile.variables.keys() if var[0:5] in s]
+        print(var)
+        matching = [s.lower() for s in ncFile.variables.keys()
+                    if var[0:13].lower() in s]
         if (len(matching) > 0):
             dd[var] = common._ncvar_to_dict(ncFile.variables[name_map[var]])
             data = ncFile.variables[name_map[var]]
@@ -275,7 +277,7 @@ def read_nasa_ames(filename, mapping_dict=None, platform=None):
             name_map = _get_name_map(platform)
         else:
             name_map = _make_name_map_from_varlist(hdr['VNAME'])
-
+    print(name_map)
     # Loop through the variables and pull data
     readfile = {}
 
@@ -306,11 +308,19 @@ def read_nasa_ames(filename, mapping_dict=None, platform=None):
     readfile['time'] = Time
 
     data = {}
+    print(readfile)
+    sht_var = [elem[:37].lower() for elem in readfile.keys()]
+    print(sht_var)
+    print('keys')
+    print(name_map.keys())
     for varname in name_map:
         try:
+            matching = sht_var.index(name_map[varname][:37].lower())
+            print(varname, matching, list(readfile.keys())[matching])
             data[varname] = common._nasa_ames_var_to_dict(
-                               readfile[name_map[varname]],
+                               readfile[list(readfile.keys())[matching]],
                                varname, name_map[varname])
+
         except:
             data[varname] = None
 

--- a/awot/io/name_maps_flight.py
+++ b/awot/io/name_maps_flight.py
@@ -274,6 +274,10 @@ def _latmos_name_map():
         "longitude": "longitude : from GPS (degree)",
         "altitude": "altitude : from GPS (meter)",
         "true_heading": "platform_orientation : from INS (degree)",
+        "true_heading1": "Aircraft heading angle from the Applanix Position "
+                         "and Orientation System (POS); 0 to 360 range with "
+                         "0 being North and angles increasing in a clockwise "
+                         "(right) direction [degrees].",
         "temperature":
         "air_temperature : from deiced Rosemount sensor (Celsius)",
         "dewpoint_temperature": "dew_point_temperature : from 1011B "
@@ -305,8 +309,14 @@ def _latmos_name_map():
                                         "from GPS (m/s)",
         "attack_angle": "angle_of_attack : from sensor on the boom "
                         "(degree)",
+        "attack_angle1": "Alpha (Attack) Angle based on Nose Pitot Pressure "
+                         "[degrees] {Calibration:  slope = 0.066317100 offset "
+                         "= 0.40082229}",
         "sideslip_angle": "angle_of_sideslip : from sensor on the "
                           "boom (degree)",
+        "sideslip_angle1": "Beta (Sideslip) Angle based on Nose Pitot "
+                           "Pressure [degrees] {Calibration:  slope = "
+                           "0.085875130 offset = 0.16014451}",
         "Uwind": "eastward_wind : Attitudes and speed wrt ground from "
                  "INS, air angles from radome, air speed from pitot (m/s)",
         "Vwind": "northward_wind : Attitudes and speed wrt ground from "
@@ -368,6 +378,10 @@ def _und_citation_name_map():
         'pitch': "Aircraft Pitch Angle from the Applanix POS System [degrees]",
         'true_heading': "Aircraft Heading Angle [degrees]; 0-360 with 0 "
                         "being North",
+        'true_heading1': "Aircraft heading angle from the Applanix Position "
+                         "and Orientation System (POS); 0 to 360 range with 0 "
+                         "being North and angles increasing in a clockwise "
+                         "(right) direction [degrees].",
         'aircraft_vert_accel': "Aircraft Z-direction (Vertical) Acceleration "
                                "for the Applanix POS system [m/s^2]",
         'latitude': "Aircraft Latitude from the Applanix POS System [degrees]",
@@ -375,14 +389,26 @@ def _und_citation_name_map():
                      "[degrees]",
         'altitude': "Aircraft Altitude from the Applanix POS system [m]",
         'aircraft_speed': "Aircraft Speed from the Applanix POS system [m/s]",
+        'aircraft_speed1': "Aircraft ground speed from the Applanix Position "
+                           "and Orientation System (POS) [m/s]",
         'track': "Aircraft Track Angle [degrees]; 0-360 with 0 "
                  "being North",
+        'track1': "Aircraft track angle from the Applanix Position and "
+                  "Orientation System (POS); 0 to 360 range with 0 being "
+                  "North.and angles increasing in a clockwise (right) "
+                  "direction [degrees].",
         'attack_angle': "Alpha (Attack) Angle [degrees] "
                         "{Calibration:  slope = 0.070310700 "
                         "offset = 0.33308870}",
+        'attack_angle1': "Alpha (Attack) Angle based on Nose Pitot Pressure "
+                         "[degrees] {Calibration:  slope = 0.066317100 "
+                         "offset = 0.40082229}",
         'sideslip_angle': "Beta (Sideslip) Angle [degrees] "
                           "{Calibration:  slope = -0.073846080 "
                           "offset = -1.6202790}",
+        'sideslip_angle1': "Beta (Sideslip) Angle based on Nose Pitot "
+                           "Pressure [degrees] {Calibration:  slope = "
+                           "0.085875130 offset = 0.16014451}",
         'aicrcaft_vert_vel': "Vertical Velocity of the aircraft based on "
                              "the change in position over a 2 seceond "
                              "interval [m/s]",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ doclines = __doc__.split("\n")
 # - Versioning
 MAJOR = 0
 MINOR = 2
-MICRO = 11
+MICRO = 12
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 # - Set variables for setup


### PR DESCRIPTION
This fix addresses the issue where there are slight differences in the `readfile.keys` and the `name_map`.  It currently finds the first 36 characters and matches them.  This could be user specifiable in case of issues with other platforms/datasets, but that is not implemented yet.

Tested using a und_citation file from GCPEx against the name_map generated for MC3E.
